### PR TITLE
pytest 3.7.0 breaks async fixtures

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,10 @@ setup(
     include_package_data=True,
     install_requires=[
         "asyncio-cancel-token==0.1.0a2",
-        "pytest>=3.3.2,<4",
+        # pytest 3.7.0 broke async fixtures.
+        # https://github.com/pytest-dev/pytest-asyncio/issues/89
+        "pytest>=3.3.2,<3.7.0",
+        "pytest-asyncio>=0.8.0,<1",
     ],
     setup_requires=['setuptools-markdown'],
     python_requires='>=3.6, <4',


### PR DESCRIPTION
## What was wrong?

https://github.com/pytest-dev/pytest-asyncio/issues/89

## How was it fixed?

pin to earlier version

#### Cute Animal Picture

![18 baby-animals](https://user-images.githubusercontent.com/824194/43475323-a35387dc-94b2-11e8-87c9-fbc02bc828b8.jpg)
