### PR TITLE
Christoph/spring cleaning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,9 @@ chains
 .cache
 .pytest_cache
 
+# mypy
+.mypy_cache
+
 # Test output logs
 logs
 ### JetBrains template

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,14 @@
+[mypy]
+
+check_untyped_defs = True
+disallow_incomplete_defs = True
+disallow_untyped_defs = True
+disallow_any_generics = True
+disallow_untyped_calls = True
+disallow_subclassing_any = True
+ignore_missing_imports = True
+strict_optional = True
+strict_equality = True
+warn_redundant_casts = True
+warn_unused_configs = True
+warn_unused_ignores = True

--- a/pytest_asyncio_network_simulator/__init__.py
+++ b/pytest_asyncio_network_simulator/__init__.py
@@ -1,4 +1,12 @@
-from .address import Address  # noqa: F401
-from .host import Host  # noqa: F401
-from .network import Network  # noqa: F401
-from .router import Router  # noqa: F401
+from .address import (  # noqa: F401
+    Address,
+)
+from .host import (  # noqa: F401
+    Host,
+)
+from .network import (  # noqa: F401
+    Network,
+)
+from .router import (  # noqa: F401
+    Router,
+)

--- a/pytest_asyncio_network_simulator/host.py
+++ b/pytest_asyncio_network_simulator/host.py
@@ -20,8 +20,8 @@ from .utils import (
 
 
 class Host:
-    servers: Dict[int, Server] = None
-    connections: Dict[int, Address] = None
+    servers: Dict[int, Server]
+    connections: Dict[int, Address]
 
     def __init__(self, host: str, router: Router) -> None:
         self.router = router

--- a/pytest_asyncio_network_simulator/network.py
+++ b/pytest_asyncio_network_simulator/network.py
@@ -49,7 +49,7 @@ DEFAULT_PATHS = ('start_server', 'open_connection')
 class Network:
     router: Router
     name: str
-    _default_host: str = None
+    _default_host: str
 
     def __init__(self, name: str, router: Router, default_host: str=None) -> None:
         self.name = name

--- a/setup.py
+++ b/setup.py
@@ -49,9 +49,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "asyncio-cancel-token==0.1.0a2",
-        # pytest 3.7.0 broke async fixtures.
-        # https://github.com/pytest-dev/pytest-asyncio/issues/89
-        "pytest>=3.3.2,<3.7.0",
+        "pytest>=3.3.2,<5",
         "pytest-asyncio>=0.8.0,<1",
     ],
     setup_requires=['setuptools-markdown'],

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ extras_require = {
     'lint': [
         "flake8==3.4.1",
         "isort>=4.2.15,<5",
-        "mypy==0.610",
+        "mypy==0.701",
     ],
     'doc': [
         "Sphinx>=1.6.5,<2",

--- a/tox.ini
+++ b/tox.ini
@@ -40,4 +40,4 @@ extras=lint
 commands=
     flake8 {toxinidir}/pytest_asyncio_network_simulator {toxinidir}/tests
     isort --recursive --check-only --diff {toxinidir}/pytest_asyncio_network_simulator {toxinidir}/tests
-    mypy --follow-imports=silent --ignore-missing-imports --no-strict-optional --check-untyped-defs --disallow-incomplete-defs --disallow-untyped-defs --disallow-any-generics pytest_asyncio_network_simulator
+    mypy -p pytest_asyncio_network_simulator --config-file {toxinidir}/mypy.ini


### PR DESCRIPTION
## What was wrong?

1. The pinned pytest prevents Trinity from using a more recent pytest version. The reason why pytest was pinned is already fixed which is why I put the upper bound to `<5`.

2. Mypy was outdated, didn't use a `mypy.ini` and could use some more stricter checking

3. `isort` wasn't happy

## How was it fixed?

1. Put `pytest` upper bound to `<5`
2. Migrated `mypy` to use a`mypy.ini` + stricter checks
3. Fixed isort issues. 

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://www.parrots-fertileeggs.com/wp-content/uploads/2018/11/bird-bath-1024x576.jpg)
